### PR TITLE
refactor: rename CleanEnvVar as Clean and panic on missing Clean

### DIFF
--- a/knob.go
+++ b/knob.go
@@ -29,7 +29,7 @@ type initializer func(*state)
 type Definition[T any] struct {
 	Default T
 	Origins []Origin // Default and Env origins are implicit
-	EnvVars []string
+	EnvVars []EnvVar
 	Clean   func(string, T) (T, bool)
 }
 

--- a/knob_test.go
+++ b/knob_test.go
@@ -25,10 +25,10 @@ func TestInitialize(t *testing.T) {
 	t.Run("env unset", func(t *testing.T) {
 		def := &Definition[string]{
 			Default: "default",
-      EnvVars: []EnvVar{{key: "TEST_KNOB_INIT"}},
-      Clean: func(v string, _ string /* default value */) (string, bool) {
-			  return v, true
-		  },
+			EnvVars: []EnvVar{{key: "TEST_KNOB_INIT"}},
+			Clean: func(v string, _ string /* default value */) (string, bool) {
+				return v, true
+			},
 		}
 		knob := Register(def)
 
@@ -39,9 +39,12 @@ func TestInitialize(t *testing.T) {
 	t.Run("env set", func(t *testing.T) {
 		def := &Definition[string]{
 			Default: "default",
+			EnvVars: []EnvVar{{key: "TEST_KNOB_INIT"}},
+			Clean: func(v string, _ string /* default value */) (string, bool) {
+				return v, true
+			},
 		}
 		t.Setenv("TEST_KNOB_INIT", "env value")
-		def.EnvVars = []EnvVar{{key: "TEST_KNOB_INIT"}}
 		knob := Register(def)
 
 		value := Get(knob)
@@ -50,6 +53,9 @@ func TestInitialize(t *testing.T) {
 	t.Run("multi env var", func(t *testing.T) {
 		def := &Definition[string]{
 			Default: "default",
+			Clean: func(v string, _ string /* default value */) (string, bool) {
+				return v, true
+			},
 		}
 		t.Setenv("TEST_KNOB_INIT", "env value")
 		t.Setenv("TEST_KNOB_INIT_2", "env_value_2")
@@ -62,6 +68,9 @@ func TestInitialize(t *testing.T) {
 	t.Run("with envvar transform", func(t *testing.T) {
 		def := &Definition[string]{
 			Default: "0.0",
+			Clean: func(v string, _ string /* default value */) (string, bool) {
+				return v, true
+			},
 		}
 		t.Setenv("TEST_KNOB_INIT", "parentbased_always_on")
 
@@ -175,7 +184,7 @@ func TestIntKnobFromEnv(t *testing.T) {
 	t.Setenv("TEST_KNOB_INT", "42")
 
 	def := &Definition[int]{
-		EnvVars: []string{"TEST_KNOB_INT"},
+		EnvVars: []EnvVar{{key: "TEST_KNOB_INT"}},
 		Clean:   func(v string, _ int) (int, bool) { i, _ := strconv.Atoi(v); return i, true },
 	}
 	knob := Register(def)


### PR DESCRIPTION
This is a temporary change, as I'm thinking how to avoid misusing the `Clean` by missing setting it - it's not nice to panic - and allowing for better reuse of common cases (converting from string to anything numerical, for instance).

I think we need to introduce a function `NewDefinition` or evolve `Register` to handle all these aspects transparently.